### PR TITLE
Added mappings from grade number to english

### DIFF
--- a/frontend/src/app/competitors/[slug]/page.tsx
+++ b/frontend/src/app/competitors/[slug]/page.tsx
@@ -55,7 +55,7 @@ async function CompetitorDetail({ params } : CompetitorProps) {
                     <div>
                         <div className="text-sm text-gray-600 mb-1">Grade</div>
                         <div className="text-lg font-semibold text-gray-800">
-                            {{1:'Freshman', 2:'Sophomore', 3:'Junior', 4:'Senior', 5:'Graduate', 7:'Alum'}[grade] || 'Unknown'}
+                            {{1:'Freshman', 2:'Sophomore', 3:'Junior', 4:'Senior', 5:'Graduate', 7:'Alum'}[grade] || 'N/A'}
                         </div>
                     </div>
                     <div>


### PR DESCRIPTION
Before if you looked at someone's competitor page, it would have a number for their grade. This was confusing when it came to graduate students, alumni, etc.
Now it maps as follows:
1 - Freshman
2 - Sophomore
3 - Junior
4 - Senior 
5 - Graduate 
7 - Alum
other - Unknown
(I know there's a gap there, it's just how we arbitrarily chose the numbers before) 